### PR TITLE
Insert after cache

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,17 +9,17 @@ import (
 )
 
 // We need to inject our plugin after the cache plugin for caching to work
-func findCache() int {
+func findCacheIndex() int {
 	for i, value := range dnsserver.Directives {
 		if value == "cache" {
-			return i + 1
+			return i
 		}
 	}
 	return -1
 }
 
-var cachePos = findCache()
-var directives = append(dnsserver.Directives[:cachePos], append([]string{"mdns"}, dnsserver.Directives[cachePos:]...)...)
+var cachePos = findCacheIndex()
+var directives = append(dnsserver.Directives[:cachePos + 1], append([]string{"mdns"}, dnsserver.Directives[cachePos + 1:]...)...)
 
 func init() {
 	dnsserver.Directives = directives

--- a/main.go
+++ b/main.go
@@ -8,7 +8,18 @@ import (
 	"github.com/coredns/coredns/coremain"
 )
 
-var directives = append([]string{"mdns"}, dnsserver.Directives...)
+// We need to inject our plugin after the cache plugin for caching to work
+func findCache() int {
+	for i, value := range dnsserver.Directives {
+		if value == "cache" {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+var cachePos = findCache()
+var directives = append(dnsserver.Directives[:cachePos], append([]string{"mdns"}, dnsserver.Directives[cachePos:]...)...)
 
 func init() {
 	dnsserver.Directives = directives

--- a/pkg/mdns/mdns.go
+++ b/pkg/mdns/mdns.go
@@ -67,6 +67,11 @@ func (m MDNS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	msg.SetReply(r)
 	state := request.Request{W: w, Req: r}
 
+	if state.QName()[len(state.QName())-len(m.Domain)-1:] != m.Domain + "." {
+		log.Debug("Skipping due to query not in our domain")
+		return plugin.NextOrFailure(m.Name(), m.Next, ctx, w, r)
+	}
+
 	if state.QType() != dns.TypeA && state.QType() != dns.TypeAAAA && state.QType() != dns.TypeSRV && state.QType() != dns.TypeCNAME {
 		log.Debug("Skipping due to unrecognized query type")
 		return plugin.NextOrFailure(m.Name(), m.Next, ctx, w, r)


### PR DESCRIPTION
We need to insert the mdns plugin after the cache plugin to allow caching to work. In addition, because the mdns plugin is earlier in the list we need to make sure we ignore queries that aren't for our configured domain. Otherwise we waste time resolving mdns when there is no chance of the query matching.