### PR TITLE
Generate A records for specified name, not always query name

### DIFF
--- a/pkg/mdns/mdns.go
+++ b/pkg/mdns/mdns.go
@@ -51,9 +51,9 @@ func (m MDNS) AddARecord(msg *dns.Msg, state *request.Request, hosts map[string]
 	// provides common code for doing so.
 	answerEntry, present := hosts[name]
 	if present {
-		aheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}
+		aheader := dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}
 		msg.Answer = append(msg.Answer, &dns.A{Hdr: aheader, A: answerEntry.AddrV4})
-		aaaaheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}
+		aaaaheader := dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}
 		msg.Answer = append(msg.Answer, &dns.AAAA{Hdr: aaaaheader, AAAA: answerEntry.AddrV6})
 		return true
 	}


### PR DESCRIPTION
When we generate a CNAME record, we add A and AAAA records to it that
shouldn't point at the query name. The code for creating those
records was previously ignoring the specified name and always using
the query name, which breaks anything referring to the CNAME.