### PR TITLE
fix Dockerfile builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 WORKDIR /go/src/github.com/metalkube/coredns-mdns
 COPY . .
-RUN go get -v github.com/coredns/coredns github.com/hashicorp/mdns golang.org/x/net/context
-RUN go build -o coredns .
+RUN git clone https://github.com/coredns/coredns /go/src/github.com/coredns/coredns
+WORKDIR /go/src/github.com/coredns/coredns
+RUN git apply /go/src/github.com/metalkube/coredns-mdns/containerization/mdns.patch && \
+    make
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/metalkube/coredns-mdns/coredns /usr/bin/
+COPY --from=builder /go/src/github.com/coredns/coredns/coredns /usr/bin/
 
 ENTRYPOINT ["/usr/bin/coredns"]
 

--- a/containerization/mdns.patch
+++ b/containerization/mdns.patch
@@ -1,0 +1,12 @@
+diff --git a/plugin.cfg b/plugin.cfg
+index 4ada8f29..2a7f1845 100644
+--- a/plugin.cfg
++++ b/plugin.cfg
+@@ -36,6 +36,7 @@ dnstap:dnstap
+ chaos:chaos
+ loadbalance:loadbalance
+ cache:cache
++mdns:github.com/metalkube/coredns-mdns/pkg/mdns
+ rewrite:rewrite
+ dnssec:dnssec
+ autopath:autopath


### PR DESCRIPTION
`go get` was having some issues with opentracing that coredns was not
having. Change the way we build coredns so that does not happen anymore.