### PR TITLE
Switch from hashicorp to micro mdns library

### DIFF
--- a/pkg/mdns/mdns.go
+++ b/pkg/mdns/mdns.go
@@ -12,7 +12,7 @@ import (
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
-	"github.com/hashicorp/mdns"
+	"github.com/micro/mdns"
 	"github.com/miekg/dns"
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
It appears the hashicorp one is largely abandoned. The fork at micro/mdns
is better maintained and fixes the annoying error messages that we
previously saw:

[ERR] mdns: Failed to read packet: read udp4 0.0.0.0:44505: use of closed network connection
[ERR] mdns: Failed to read packet: read udp6 [::]:34100: use of closed network connection
[ERR] mdns: Failed to read packet: read udp4 0.0.0.0:5353: use of closed network connection
[ERR] mdns: Failed to read packet: read udp6 [::]:5353: use of closed network connection