### PR TITLE
 Move mDNS browsing to a goroutine 

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -113,7 +113,7 @@ func (m MDNS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	log.Debug(cnames)
 	cnameTarget, present := cnames[state.Name()]
 	if present {
-		cnameheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 60}
+		cnameheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 0}
 		msg.Answer = append(msg.Answer, &dns.CNAME{Hdr: cnameheader, Target: cnameTarget})
 		m.AddARecord(msg, &state, mdnsHosts, cnameTarget)
 		log.Debug(msg)
@@ -123,7 +123,7 @@ func (m MDNS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	srvEntry, present := srvHosts[state.Name()]
 	if present {
-		srvheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeSRV, Class: dns.ClassINET, Ttl: 60}
+		srvheader := dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeSRV, Class: dns.ClassINET, Ttl: 0}
 		for _, host := range srvEntry {
 			msg.Answer = append(msg.Answer, &dns.SRV{Hdr: srvheader, Target: host.Host, Priority: 0, Weight: 10, Port: uint16(host.Port)})
 		}

--- a/setup.go
+++ b/setup.go
@@ -1,6 +1,7 @@
 package mdns
 
 import (
+	"sync"
 	"time"
 
 	"github.com/coredns/coredns/core/dnsserver"
@@ -29,7 +30,8 @@ func setup(c *caddy.Controller) error {
 	// pointers so all copies of the plugin point at the same maps.
 	mdnsHosts := make(map[string]*mdns.ServiceEntry)
 	srvHosts := make(map[string][]*mdns.ServiceEntry)
-	m := MDNS{Domain: domain, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts}
+	mutex := sync.RWMutex{}
+	m := MDNS{Domain: domain, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts}
 
 	c.OnStartup(func() error {
 		go browseLoop(&m)

--- a/setup.go
+++ b/setup.go
@@ -47,8 +47,8 @@ func setup(c *caddy.Controller) error {
 func browseLoop(m *MDNS) {
 	for {
 		m.BrowseMDNS()
-		// The OpenShift Corefile configures caching for 30 seconds, so there's little
-		// point in updating more often than that.
-		time.Sleep(30 * time.Second)
+		// 5 seconds seems to be the minimum ttl that the cache plugin will allow
+		// Since each browse operation takes around 2 seconds, this should be fine
+		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
This will speed up answering queries by responding from the state what
the background goroutine updates.